### PR TITLE
fix a bug about json middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,15 @@ client.post('add', {
 });
 ```
 
+### credentials
+
+Set credentials options to fetch. If you want to automatically send cookies for the current domain, use this middleware and config it as `same-origin`.
+
+```js
+// Add credentials middleware
+client.addMiddleware(credentials('same-origin'));
+```
+
 # Feedback
 
 If you have any questions, use [Issues](https://github.com/starlight36/fetch-http-client/issues).

--- a/modules/index.js
+++ b/modules/index.js
@@ -124,9 +124,9 @@ export const form = () => request => {
 export const json = () => request => {
   if (request.options.json) {
     request.options.body = JSON.stringify(request.options.json);
-    request.options.headers.Accept = 'application/json';
     request.options.headers['Content-Type'] = 'application/json';
   }
+  request.options.headers.Accept = 'application/json';
 
   return response => {
     const contentType = response.headers.get('Content-Type') || '';

--- a/modules/index.js
+++ b/modules/index.js
@@ -144,3 +144,7 @@ export const userAgent = ua => request => {
   Object.keys(ua).forEach(key => uaSegments.push(`${key}/${ua[key]}`));
   request.options.headers['User-Agent'] = uaSegments.join(' ');
 };
+
+export const credentials = credentials => request => {
+  request.options.credentials = credentials;
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fetch-http-client",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "A http client wrapper for fetch api with middleware support.",
   "main": "lib",
   "files": [

--- a/test/test.js
+++ b/test/test.js
@@ -178,6 +178,30 @@ describe('Middleware json', done => {
     assert.equal(request.options.headers['Content-Type'], 'application/json');
     assert.equal(request.options.headers.Accept, 'application/json');
   });
+
+  it('should handle request without body and response.', () => {
+    const request = {
+      options: {
+        headers: {},
+      },
+    };
+
+    const response = {
+      headers: {
+        get: key => {
+          assert.equal(key, 'Content-Type');
+          return 'application/json';
+        },
+      },
+      json: () => Promise.resolve(({ key: 'value' })),
+    };
+
+    json()(request)(response).then(response => {
+      assert.equal(response.jsonData, { key: 'value' });
+      done();
+    });
+    assert.equal(request.options.headers.Accept, 'application/json');
+  });
 });
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import FetchHttpClient, { query, form, json, header, userAgent } from '../modules';
+import FetchHttpClient, { query, form, json, header, userAgent, credentials } from '../modules';
 
 describe('FetchHttpClient', () => {
   it('should be a class.', () => {
@@ -202,5 +202,15 @@ describe('Middleware userAgent', () => {
     };
     userAgent({ Test: 'test', Test2: 'test2' })(request);
     assert.equal(request.options.headers['User-Agent'], 'Test/test Test2/test2');
+  });
+});
+
+describe('Middleware credentials', () => {
+  it('should set credentials options on request.', () => {
+    const request = {
+      options: {},
+    };
+    credentials('same-origin')(request);
+    assert.equal(request.options.credentials, 'same-origin');
   });
 });


### PR DESCRIPTION
If I have not setted 'json' when I use 'GET' method, there is no header about json in request  
