### PR TITLE
Adding support for ES7 async/await syntax

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -29,7 +29,7 @@ export default class FetchHttpClient {
     return this;
   }
 
-  fetch(path, options = {}) {
+  async fetch(path, options = {}) {
     if (typeof fetch !== 'function') {
       throw new TypeError('fetch() function not available');
     }
@@ -55,28 +55,28 @@ export default class FetchHttpClient {
     ));
   }
 
-  request(path, method, options = {}) {
-    return this.fetch(path, { ...options, method });
+  async request(path, method, options = {}) {
+    return await this.fetch(path, { ...options, method });
   }
 
-  get(path, options = {}) {
-    return this.request(path, 'GET', options);
+  async get(path, options = {}) {
+    return await this.request(path, 'GET', options);
   }
 
-  post(path, options = {}) {
-    return this.request(path, 'POST', options);
+  async post(path, options = {}) {
+    return await this.request(path, 'POST', options);
   }
 
-  put(path, options = {}) {
-    return this.request(path, 'PUT', options);
+  async put(path, options = {}) {
+    return await this.request(path, 'PUT', options);
   }
 
-  delete(path, options = {}) {
-    return this.request(path, 'DELETE', options);
+  async delete(path, options = {}) {
+    return await this.request(path, 'DELETE', options);
   }
 
-  patch(path, options = {}) {
-    return this.request(path, 'PATCH', options);
+  async patch(path, options = {}) {
+    return await this.request(path, 'PATCH', options);
   }
 
   resolveUrl(path, variables = {}) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "lint": "eslint modules test",
-    "test": "mocha --compilers js:babel-core/register --reporter spec --bail test/",
+    "test": "mocha --compilers js:babel-core/register --reporter spec --require babel-polyfill --bail test/",
     "test-cov": "babel-node ./node_modules/.bin/babel-istanbul cover _mocha -- --reporter dot test/",
     "test-travis": "babel-node ./node_modules/.bin/babel-istanbul cover _mocha --report lcovonly -- --reporter dot test/",
     "build": "babel ./modules -d lib && webpack modules/index.js umd/fetch-http-client.js && webpack -p modules/index.js umd/fetch-http-client.min.js",
@@ -41,6 +41,7 @@
     "babel-eslint": "~6.0.4",
     "babel-istanbul": "^0.11.0",
     "babel-loader": "^6.2.4",
+    "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "~6.6.0",
     "babel-preset-stage-0": "^6.5.0",
     "eslint": "~2.9.0",


### PR DESCRIPTION
 #7 Allows support for ES7 async/await syntax.

This allows the user to write much simpler code (less nesting).

```js
    // Create a new client object.
    const client = new FetchHttpClient('http://api.example.com/endpoint');

    // Add json support
    client.addMiddleware(json());

    // Add async middleware
    client.addMiddleware(async request => {
        const token = await AsyncStorage.getItem('@myApp:auth_token');
        if (token) {
            request.options.headers['X-Authorization'] = token;
        }
        return request;
    });
    
    // Fire request.
    const response = await client.get('test');

    // access json data
    console.log(response.jsonData);
```